### PR TITLE
Add Park Slope image to Chapter 0

### DIFF
--- a/chapter0.html
+++ b/chapter0.html
@@ -126,6 +126,15 @@
       header img:hover {
         transform: scale(1.05);
       }
+      .location-image {
+        display: block;
+        width: 90%;
+        max-width: 750px;
+        margin: 1.5rem auto;
+        border: 3px solid #ff1493;
+        box-shadow: 0 0 30px #ff1493;
+        border-radius: 10px;
+      }
       /* AUDIO CONTAINER */
       .audio-container {
         background: rgba(0, 0, 0, 0.95);
@@ -262,6 +271,8 @@
         alt="Red Echo Header"
       />
     </header>
+
+    <img src="parkslopeapt.png" alt="Park Slope Apartment" class="location-image" />
 
     <!-- Audio Container with narration -->
     <div class="audio-container">


### PR DESCRIPTION
## Summary
- show the `parkslopeapt.png` apartment image before the audio player in Chapter 0
- style the new image with neon borders and shadow

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68506d30da688333b6efc69947101665