### PR TITLE
Fix Leaflet icon paths

### DIFF
--- a/gowanus_interactive_map.html
+++ b/gowanus_interactive_map.html
@@ -4,6 +4,14 @@
     
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
+    <script>
+        const iconPath = "https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/images/";
+        L.Icon.Default.mergeOptions({
+            iconRetinaUrl: iconPath + "marker-icon-2x.png",
+            iconUrl: iconPath + "marker-icon.png",
+            shadowUrl: iconPath + "marker-shadow.png",
+        });
+    </script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>

--- a/retro_mta_story_map.html
+++ b/retro_mta_story_map.html
@@ -4,6 +4,14 @@
     
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
+    <script>
+        const iconPath = "https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/images/";
+        L.Icon.Default.mergeOptions({
+            iconRetinaUrl: iconPath + "marker-icon-2x.png",
+            iconUrl: iconPath + "marker-icon.png",
+            shadowUrl: iconPath + "marker-shadow.png",
+        });
+    </script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>

--- a/retro_parkslope_map2.html
+++ b/retro_parkslope_map2.html
@@ -4,6 +4,14 @@
     
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
+    <script>
+        const iconPath = "https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/images/";
+        L.Icon.Default.mergeOptions({
+            iconRetinaUrl: iconPath + "marker-icon-2x.png",
+            iconUrl: iconPath + "marker-icon.png",
+            shadowUrl: iconPath + "marker-shadow.png",
+        });
+    </script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>


### PR DESCRIPTION
## Summary
- set correct Leaflet marker icon path in interactive map pages

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685073ed05d0833389157b7cfa58dca6