### PR TITLE
Show Gowanus and MTA route maps

### DIFF
--- a/chapter0.html
+++ b/chapter0.html
@@ -245,8 +245,13 @@
     <!-- Transcript Container -->
     <div class="transcript" id="transcript"></div>
 
-    <!-- Map from Chapter 1 shown after transcript -->
-    <div class="map-container" id="chapterMap" style="display:none;">
+    <!-- Retro Gowanus Map -->
+    <div class="map-container" id="gowanusMap">
+      <iframe src="retro_parkslope_map2.html" width="100%" height="450" style="border:none"></iframe>
+    </div>
+
+    <!-- Retro MTA Route Map -->
+    <div class="map-container" id="chapterMap">
       <iframe src="retro_mta_story_map.html" width="100%" height="450" style="border:none"></iframe>
     </div>
 


### PR DESCRIPTION
## Summary
- display a retro map of Gowanus/Park Slope
- display the retro MTA route map

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68508d08360c8333bd782695c415b688