### PR TITLE
Add SRT timing and typing effect for Chapter 1

### DIFF
--- a/js/transcribe.js
+++ b/js/transcribe.js
@@ -26,19 +26,36 @@ function attachTranscription(audio, transcriptUrl) {
       }
 
       let active = -1;
+      let typingTimer;
+
+      const typeCaption = (text, duration) => {
+        clearInterval(typingTimer);
+        container.textContent = '';
+        let index = 0;
+        const delay = Math.max(duration / Math.max(text.length, 1), 0.01) * 1000;
+        typingTimer = setInterval(() => {
+          container.textContent += text.charAt(index);
+          index++;
+          if (index >= text.length) {
+            clearInterval(typingTimer);
+          }
+        }, delay);
+      };
+
       const update = () => {
         const t = audio.currentTime;
         for (let i = 0; i < captions.length; i++) {
           const c = captions[i];
           if (t >= c.start && t <= c.end) {
             if (i !== active) {
-              container.textContent = c.text;
+              typeCaption(c.text, c.end - c.start);
               active = i;
             }
             return;
           }
         }
         if (active !== -1) {
+          clearInterval(typingTimer);
           container.textContent = '';
           active = -1;
         }

--- a/transcripts/chapter1.txt
+++ b/transcripts/chapter1.txt
@@ -1,1 +1,83 @@
-Placeholder transcript for Chapter 1.
+1
+00:00:00,000 --> 00:00:05,001
+Coney Island in the
+
+2
+00:00:05,001 --> 00:00:10,002
+Summer:
+
+3
+00:00:10,002 --> 00:00:15,004
+The sand is hot enough to fry a knish, the boardwalk’s creaky as hell, and some guy in a tank top that says "BOSS OF ALL BOSSES" is screaming at
+
+4
+00:00:15,004 --> 00:00:20,005
+a claw machine like it owes him money.
+
+5
+00:00:20,005 --> 00:00:25,006
+There’s a kid crying.
+
+6
+00:00:25,006 --> 00:00:30,008
+There’s always a kid crying.
+
+7
+00:00:30,008 --> 00:00:35,009
+I weave through the boardwalk chaos, past the fortune tellers and the knockoff Oakley vendors, past a guy who’s either selling hot dogs or running a numbers game, or both, maybe. My brain says I should go hit the Cyclone first, ya know, let my bones realign themselves through some high-velocity chiropractic adjustment, but my gut says otherwise.
+
+8
+00:00:35,009 --> 00:00:40,010
+My gut says
+
+9
+00:00:40,010 --> 00:00:45,012
+something’s off.
+
+10
+00:00:45,012 --> 00:00:50,013
+The arcades are mostly the same as they’ve always been. Sticky floors, busted air conditionin', cigarette burns on the cabinets. A small congregation of teenagers hovers around Tekken 3, throwing around some insults that’d make their grandmothers faint silly, but there’s something different here.
+
+11
+00:00:50,013 --> 00:00:55,014
+Something... weird.
+
+12
+00:00:55,014 --> 00:01:00,016
+The Machine
+
+13
+00:01:00,016 --> 00:01:05,017
+It’s in the back corner, where the light don’t hardly reach.
+
+14
+00:01:05,017 --> 00:01:10,018
+Literally, there’s a whole string of half-dead bulbs above it, flickering just enough to make it look like this thing exists in some slightly different dimension.
+
+15
+00:01:10,018 --> 00:01:15,020
+No marquee. No branding.
+
+16
+00:01:15,020 --> 00:01:20,021
+Just a plain black cabinet with a glowing start button.
+
+17
+00:01:20,021 --> 00:01:25,022
+I don’t even see nowhere for the quarters to go.
+
+18
+00:01:25,022 --> 00:01:30,024
+Shit, I think this
+
+19
+00:01:30,024 --> 00:01:35,025
+baby is free play!
+
+20
+00:01:35,025 --> 00:01:40,026
+I steps a little closer.
+
+21
+00:01:40,026 --> 00:01:45,028
+The screen flickers and what not…


### PR DESCRIPTION
## Summary
- convert Chapter 1 transcript to SRT format
- animate transcript display with a typewriter effect while audio plays

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68508d5a2ed883338fb76514d5afa12d