### PR TITLE
Improve transcript sync typing effect

### DIFF
--- a/js/transcribe.js
+++ b/js/transcribe.js
@@ -28,17 +28,21 @@ function attachTranscription(audio, transcriptUrl) {
       let active = -1;
       const update = () => {
         const t = audio.currentTime;
+        let found = false;
         for (let i = 0; i < captions.length; i++) {
           const c = captions[i];
           if (t >= c.start && t <= c.end) {
-            if (i !== active) {
-              container.textContent = c.text;
+            if (active !== i) {
               active = i;
             }
-            return;
+            const progress = (t - c.start) / (c.end - c.start);
+            const len = Math.floor(progress * c.text.length);
+            container.textContent = c.text.slice(0, len);
+            found = true;
+            break;
           }
         }
-        if (active !== -1) {
+        if (!found) {
           container.textContent = '';
           active = -1;
         }


### PR DESCRIPTION
## Summary
- make transcripts progressively reveal text so captions type out alongside audio

## Testing
- `node --check js/transcribe.js`

------
https://chatgpt.com/codex/tasks/task_e_68508ff5d2f883338e9c7cca3924e24f