### PR TITLE
Update chapter0 map

### DIFF
--- a/chapter0.html
+++ b/chapter0.html
@@ -247,7 +247,7 @@
 
     <!-- Retro Gowanus Map -->
     <div class="map-container" id="gowanusMap">
-      <iframe src="retro_parkslope_map2.html" width="100%" height="450" style="border:none"></iframe>
+      <iframe src="retro_parkslope_map.html" width="100%" height="450" style="border:none"></iframe>
     </div>
 
     <!-- Retro MTA Route Map -->

--- a/retro_parkslope_map.html
+++ b/retro_parkslope_map.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html>
+<head>
+    
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"/>
+    
+            <meta name="viewport" content="width=device-width,
+                initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+            <style>
+                #map_d6b6d78c7eaef72f659afc701efc0a0e {
+                    position: relative;
+                    width: 100.0%;
+                    height: 100.0%;
+                    left: 0.0%;
+                    top: 0.0%;
+                }
+                .leaflet-container { font-size: 1rem; }
+            </style>
+
+            <style>html, body {
+                width: 100%;
+                height: 100%;
+                margin: 0;
+                padding: 0;
+            }
+            </style>
+
+            <style>#map {
+                position:absolute;
+                top:0;
+                bottom:0;
+                right:0;
+                left:0;
+                }
+            </style>
+
+            <script>
+                L_NO_TOUCH = false;
+                L_DISABLE_3D = false;
+            </script>
+
+        
+    <script src="https://cdn.jsdelivr.net/gh/marslan390/BeautifyMarker/leaflet-beautify-marker-icon.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/marslan390/BeautifyMarker/leaflet-beautify-marker-icon.min.css"/>
+</head>
+<body>
+    
+    
+            <div class="folium-map" id="map_d6b6d78c7eaef72f659afc701efc0a0e" ></div>
+        
+</body>
+<script>
+    
+    
+            var map_d6b6d78c7eaef72f659afc701efc0a0e = L.map(
+                "map_d6b6d78c7eaef72f659afc701efc0a0e",
+                {
+                    center: [40.6687, -73.9885],
+                    crs: L.CRS.EPSG3857,
+                    ...{
+  "zoom": 16,
+  "zoomControl": true,
+  "preferCanvas": false,
+}
+
+                }
+            );
+
+            
+
+        
+    
+            var tile_layer_8ada743899a87d570bea0012115804eb = L.tileLayer(
+                "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+                {
+  "minZoom": 0,
+  "maxZoom": 20,
+  "maxNativeZoom": 20,
+  "noWrap": false,
+  "attribution": "\u0026copy; \u003ca href=\"https://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors \u0026copy; \u003ca href=\"https://carto.com/attributions\"\u003eCARTO\u003c/a\u003e",
+  "subdomains": "abcd",
+  "detectRetina": false,
+  "tms": false,
+  "opacity": 1,
+}
+
+            );
+        
+    
+            tile_layer_8ada743899a87d570bea0012115804eb.addTo(map_d6b6d78c7eaef72f659afc701efc0a0e);
+        
+    
+            var marker_afeedec3cfeb101b860683438fc6af70 = L.marker(
+                [40.6687, -73.9885],
+                {
+}
+            ).addTo(map_d6b6d78c7eaef72f659afc701efc0a0e);
+        
+    
+            var beautify_icon_a284e012442033af4a1ae715aa19dbf6 = new L.BeautifyIcon.icon(
+                {
+  "iconShape": "marker",
+  "borderWidth": 3,
+  "borderColor": "#22223B",
+  "textColor": "#fff",
+  "backgroundColor": "#FFB400",
+  "innerIconStyle": "",
+  "spin": false,
+  "isAlphaNumericIcon": false,
+  "iconSize": [
+38,
+38,
+],
+}
+            )
+            marker_afeedec3cfeb101b860683438fc6af70.setIcon(beautify_icon_a284e012442033af4a1ae715aa19dbf6);
+        
+    
+        var popup_bc7d374644fc6aabd94f8996600efae9 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8100444e135da1b8e87e12b92d6e4365 = $(`<div id="html_8100444e135da1b8e87e12b92d6e4365" style="width: 100.0%; height: 100.0%;">Home base, Park Slope, Summer 1997.</div>`)[0];
+                popup_bc7d374644fc6aabd94f8996600efae9.setContent(html_8100444e135da1b8e87e12b92d6e4365);
+            
+        
+
+        marker_afeedec3cfeb101b860683438fc6af70.bindPopup(popup_bc7d374644fc6aabd94f8996600efae9)
+        ;
+
+        
+    
+    
+                marker_afeedec3cfeb101b860683438fc6af70.setIcon(beautify_icon_a284e012442033af4a1ae715aa19dbf6);
+            
+</script>
+</html>


### PR DESCRIPTION
## Summary
- generate new Park Slope map with Folium
- swap first map in chapter0.html to use the new map

## Testing
- `python3 - <<'EOF'
import folium
from folium.plugins import BeautifyIcon
home_coords=[40.6687,-73.9885]
m=folium.Map(location=home_coords, zoom_start=16, tiles='CartoDB Positron')
folium.Marker(home_coords,popup="Home base, Park Slope, Summer 1997.",
             icon=BeautifyIcon(icon_shape='marker', border_color="#22223B", text_color="#fff", background_color="#FFB400", icon_size=[38,38])).add_to(m)
m.save('retro_parkslope_map.html')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685091d1557883338f470d6af9349032