### PR TITLE
Fix missing triggerFlicker and update arcade link

### DIFF
--- a/chapter1.html
+++ b/chapter1.html
@@ -153,8 +153,8 @@
 
     <div id="gameEmbed" class="game-embed">
       <iframe
-        src="https://duderockarcade.glitch.me/"
-        title="duderockarcade"
+        src="https://jimminiglitch.github.io/dudrockarcade"
+        title="dudrockarcade"
         allow="geolocation; camera; midi; encrypted-media; xr-spatial-tracking; fullscreen"
         allowfullscreen
       >
@@ -192,6 +192,12 @@
         continueBtn.style.pointerEvents = "auto";
       }, 10000);
     }, 400);
+  }
+  function triggerFlicker() {
+    document.body.classList.add("flicker");
+    setTimeout(() => {
+      window.location.href = "chapter2.html";
+    }, 300);
   }
 </script>
   </body>

--- a/chapter2.html
+++ b/chapter2.html
@@ -183,6 +183,12 @@
       }, 10000);
     }, 400);
   }
+  function triggerFlicker() {
+    document.body.classList.add("flicker");
+    setTimeout(() => {
+      window.location.href = "chapter3.html";
+    }, 300);
+  }
 </script>
 </body>
 </html>

--- a/chapter3.html
+++ b/chapter3.html
@@ -184,6 +184,12 @@
       triggerBlackout();
     }, 2000);
   }
+  function triggerFlicker() {
+    document.body.classList.add("flicker");
+    setTimeout(() => {
+      triggerGlitchOverlay();
+    }, 300);
+  }
   function triggerBlackout() {
     const blackoutOverlay = document.createElement("div");
     blackoutOverlay.className = "blackout-overlay";


### PR DESCRIPTION
## Summary
- add missing `triggerFlicker` implementations for chapters 1–3
- update embedded arcade link in chapter 1 to the GitHub Pages URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850bb0ae7dc8333b3c619d1a6ccd042