### PR TITLE
Improve terminal interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,12 @@
         justify-content: center;
         flex-direction: column;
         cursor: pointer;
+        opacity: 1;
+        transition: opacity 0.6s ease;
+      }
+      #startOverlay.hidden {
+        opacity: 0;
+        pointer-events: none;
       }
       #startOverlay h1 {
         font-family: "Press Start 2P", cursive;
@@ -198,10 +204,11 @@
         height: auto;
         border: 3px solid #ff1493;
         box-shadow: 0 0 20px #ff1493, 0 0 40px #ff1493 inset;
-        transition: transform 0.3s ease;
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
       }
       header img:hover {
         transform: scale(1.08);
+        box-shadow: 0 0 30px #ff1493, 0 0 50px #39ff14 inset;
       }
 
       /* ACCESS TERMINAL TITLE */
@@ -243,8 +250,11 @@
         padding: 20px;
         box-shadow: 0 0 20px #39ff14;
         text-align: center;
+        max-width: 320px;
+        width: 90%;
         transform: perspective(800px) rotateX(10deg) rotateY(2deg);
         transform-origin: center top;
+        transition: transform 0.3s ease;
       }
 
       /* INPUT */
@@ -276,24 +286,24 @@
       }
       .keypad button {
         font-family: "Press Start 2P", cursive;
-        font-size: 0.8rem;
+        font-size: 0.9rem;
         background: #000;
         border: 2px solid #ff1493;
         color: #ff1493;
         border-radius: 5px;
         cursor: pointer;
         box-shadow: 0 0 10px #ff1493, inset 0 0 5px #39ff14;
-        transition: all 0.2s ease;
+        transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
         text-shadow: 0 0 2px #39ff14;
       }
       .keypad button:hover {
         background: linear-gradient(135deg, #39ff14, #ff1493);
         color: #000;
         box-shadow: 0 0 15px #ff1493, 0 0 25px #39ff14, inset 0 0 10px #fff;
-        transform: translateY(-2px);
+        transform: translateY(-2px) scale(1.05);
       }
       .keypad button:active {
-        transform: translateY(1px) scale(0.98);
+        transform: translateY(1px) scale(0.95);
         box-shadow: 0 0 5px #ff1493;
       }
 
@@ -379,7 +389,16 @@
     <!-- SCRIPTS -->
     <script>
       function startTerminal() {
-        document.getElementById("startOverlay").style.display = "none";
+        const overlay = document.getElementById("startOverlay");
+        overlay.classList.add("hidden");
+        overlay.addEventListener(
+          "transitionend",
+          () => {
+            overlay.style.display = "none";
+          },
+          { once: true }
+        );
+
         const bgMusic = document.getElementById("bgMusic");
         bgMusic.volume = 0.3;
         bgMusic.play().catch(() => {});


### PR DESCRIPTION
## Summary
- add smooth fade for the opening overlay
- polish header glow and keypad interactions
- limit terminal container width and add transform transition

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6850d34dabe883338658cae7d4090fc3