### PR TITLE
Add 3D rave scene

### DIFF
--- a/3drave.html
+++ b/3drave.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3D Rave</title>
+  <script src="https://aframe.io/releases/1.4.1/aframe.min.js"></script>
+  <style>
+    body { margin: 0; background: #000; }
+    #overlay {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      color: #39ff14;
+      font-family: "Share Tech Mono", monospace;
+      z-index: 10;
+    }
+  </style>
+</head>
+<body>
+  <div id="overlay">W/A/S/D to move, mouse to look</div>
+  <a-scene>
+    <a-assets>
+      <audio id="rave-track" src="nepocorp1.mp3"></audio>
+    </a-assets>
+    <a-entity sound="src: #rave-track; autoplay: true; loop: true" position="0 1.6 0"></a-entity>
+    <a-box position="-1 0.5 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
+    <a-sphere position="1 1.25 -5" radius="1.25" color="#EF2D5E"></a-sphere>
+    <a-cylinder position="0 0.75 -2" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
+    <a-plane rotation="-90 0 0" width="20" height="20" color="#222"></a-plane>
+    <a-sky color="#000"></a-sky>
+  </a-scene>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ point it at the `main` branch to see the site online.
 A small Fastify server (`app/server.js`) is included for local development. Run
 `npm install` inside the `app` directory and then `npm start` to serve the
 files locally.
+
+An experimental page `3drave.html` is included for exploring the world in 3D.
+It uses the [A-Frame](https://aframe.io/) library with ambient audio. Run the
+server and visit `/3drave` or open the file directly in your browser.

--- a/app/server.js
+++ b/app/server.js
@@ -32,6 +32,11 @@ fastify.get("/chapter3", function (request, reply) {
   return reply.sendFile("chapter3.html");
 });
 
+// 3D rave experience
+fastify.get("/3drave", function (request, reply) {
+  return reply.sendFile("3drave.html");
+});
+
 
 // ===== START SERVER =====
 fastify.listen({ port: process.env.PORT, host: "0.0.0.0" }, function (err, address) {


### PR DESCRIPTION
## Summary
- add `3drave.html` as an experimental A-Frame scene with ambient music
- serve the new page at `/3drave` in the Fastify server
- document the feature in the project README

## Testing
- `npm test` *(fails: missing script)*
- `npm start` *(fails until deps installed; once installed server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6850d43999b4833398c984fcb518224e